### PR TITLE
Add comprehensive project documentation

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -1,0 +1,67 @@
+# BeachApp Documentation
+
+## Overview
+BeachApp is an Android application that helps users discover and review beaches in Southern California. The app integrates Google Maps for location-based browsing, provides real‑time weather and wave data, and allows users to submit and manage beach reviews. Firebase Realtime Database is used for persisting users, beaches, and reviews.
+
+## Key Features
+- **User Authentication** – Registration and login screens validate credentials and store user accounts in Firebase.
+- **Interactive Map** – `MapsActivity` displays markers for available beaches and supports filtering by common activities through a spinner control.
+- **Beach Details** – `DisplayBeachActivity` fetches beach metadata from Firebase, retrieves weather and marine forecasts through the `WeatherAPI` helper, and highlights the two most popular activities at each beach.
+- **Reviews** – Users can browse existing reviews, add new reviews with optional photos, and rate beaches. Activity tags selected during review submission are aggregated to track popularity.
+- **Portfolio** – `PortfolioActivity` shows a user profile and a list of their submitted reviews. Users may update or delete reviews, with beach ratings recalculated accordingly.
+
+## Architecture
+The application follows a multi‑activity structure:
+- `MainActivity` initializes Firebase and routes to the authentication flow.
+- `LoginActivity` and `RegisterActivity` handle user credentials.
+- `MapsActivity` hosts the Google Map and dispatches users to beach pages.
+- `DisplayBeachActivity` presents weather information and actions for viewing or managing reviews.
+- `ReviewActivity` shows all reviews for a beach and links to `AddReviewActivity` for creating a new one.
+- `PortfolioActivity` serves as a user dashboard for review management.
+
+Supporting classes include:
+- `Beach`, `Review`, and `User` model classes.
+- `WeatherAPI`, a static utility for retrieving current conditions and forecasts from Tomorrow.io and Open‑Meteo.
+
+## Data Storage
+- **Firebase Realtime Database** – Stores users, beaches, and reviews. Beach ratings are computed from stored reviews.
+- **Local JSON (`activity_tag.json`)** – Maintains counts of user‑selected activity tags per beach to surface top activities.
+
+## Build and Run
+1. Install Android Studio (Giraffe or newer) with Android SDK 34 and a configured emulator or device.
+2. Clone the repository and open it in Android Studio.
+3. Ensure a valid Firebase configuration (`google-services.json`) is present under the `app` module.
+4. Build and run the `app` module. `MainActivity` launches `LoginActivity` by default.
+
+### Command Line
+```
+sh gradlew assembleDebug   # Builds the debug APK
+sh gradlew test            # Runs unit tests (requires network access for Gradle distribution)
+```
+
+## Testing
+Unit tests reside in `app/src/test/java` and cover URL construction for weather queries, credential validation, and map utilities. Instrumentation tests live under `app/src/androidTest/java` and exercise UI flows such as login, registration, map interactions, and review screens.
+
+Attempting to run the test suite with `sh gradlew test` in a restricted environment may fail to download the Gradle distribution, resulting in an `HTTP/1.1 403 Forbidden` error.
+
+## Directory Structure
+```
+app/
+  src/main/java/com/example/beachapp/   # Activities, models, helpers
+  src/main/res/                         # Layouts, drawables, values
+  src/test/java/                        # Local unit tests
+  src/androidTest/java/                 # Instrumentation tests
+```
+
+## Dependencies
+- AndroidX AppCompat, Material Components, ConstraintLayout
+- Google Play Services Maps & Location
+- Firebase Realtime Database and Authentication
+- OkHttp for HTTP requests
+- Robolectric and Espresso for testing
+
+## Future Enhancements
+- Additional beach data and dynamic retrieval from backend sources
+- Expanded activity tagging and recommendation system
+- Offline caching for weather and review data
+

--- a/README.md
+++ b/README.md
@@ -30,6 +30,3 @@ The command requires network access to download the Gradle distribution.
 
 ## Documentation
 For a deeper exploration of the architecture, data model, and development workflow, see [DOCUMENTATION.md](DOCUMENTATION.md).
-
-## License
-This project is provided for educational purposes as part of CS310 team assignments.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,35 @@
-# CS310_TeamAssignment2_BeachApp
+# BeachApp
 
-Running the MainActivity file on a Pixel 2 with API 35 should be appropriate to support the app runtime.
+BeachApp is an Android application for discovering and reviewing beaches in Southern California. The project demonstrates a multi-activity architecture, Firebase-backed data storage, and integration with Google Maps and external weather services.
 
-We currently have a test user with the username and password of 'ss' and 'ss' respectfully, which can be inputted to grant access into the app. Additionally, Santa Monica is the only beach to have signifncant data (user reviews, star ratings) to be implemented at the moment, which is currently our benchmark for app functionality. Clicking on the corresponding Santa Monica button should open up a new page displaying all the appropriate information for that beach. It may take a second for the beach weather info to update due to API fetching occuring on a separate thread.
+## Features
+- **User Authentication** – Register and log in with credentials stored in Firebase Realtime Database.
+- **Interactive Map** – Browse available beaches on a Google Map and filter by common activities.
+- **Beach Details** – View real-time weather conditions, top activities, and existing reviews.
+- **Reviews** – Submit ratings, text, and photos; edit or delete submissions from your profile.
+- **User Portfolio** – Access a personalized dashboard listing all of your reviews.
 
-If any issues persist when trying to run the app, they may be related to: firebase authorization, currently slow overall runtime, or poor internet connection (preventing proper fetching of API data).
+## Requirements
+- Android Studio Giraffe (or newer)
+- Android SDK 34 with an emulator or physical device
+- Firebase configuration (`google-services.json`) in the `app` module
+
+## Quick Start
+1. Clone the repository.
+2. Place your `google-services.json` in `app/`.
+3. Open the project in Android Studio.
+4. Build and run the `app` module.
+5. Log in with the test credentials `ss` / `ss` or register a new account.
+
+## Testing
+Run the unit test suite from the command line:
+```bash
+sh gradlew test
+```
+The command requires network access to download the Gradle distribution.
+
+## Documentation
+For a deeper exploration of the architecture, data model, and development workflow, see [DOCUMENTATION.md](DOCUMENTATION.md).
+
+## License
+This project is provided for educational purposes as part of CS310 team assignments.


### PR DESCRIPTION
## Summary
- add a standalone `DOCUMENTATION.md` describing BeachApp architecture, features, storage, build steps, tests, and dependencies

## Testing
- `sh gradlew test` *(fails: Unable to tunnel through proxy, HTTP/1.1 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68942bc171688323b4a8f1b3f43a9f32